### PR TITLE
feat(parser): add option support to RUN instruction parsing

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -254,6 +254,10 @@ type RunInstructionNode struct {
 	Cmd       []string
 	ShellForm bool // true if shell form, false if exec form
 	IsHeredoc bool // true if heredoc
+	Device    string
+	Mount     []string
+	Network   string
+	Security  string
 }
 
 func (ri *RunInstructionNode) ToString() string {

--- a/pkg/lexer/util.go
+++ b/pkg/lexer/util.go
@@ -76,7 +76,7 @@ func (l *Lexer) advanceParam() (string, string, bool) {
 				// Support params with no passed value
 				if l.expectCurrentCharacter(' ') {
 					endIndex = l.currentIndex
-					value = "true"
+					value = "true" // these are assignments without = -> flags
 					key = l.lines[l.currentLine][currentWordStartIndex:l.currentIndex]
 					break
 				}
@@ -104,13 +104,13 @@ func (l *Lexer) buildToken(kind int) token.Token {
 		}
 		return token.Token{Kind: kind, Content: l.lines[l.currentLine][l.currentIndex:]}
 	}
-	params := make(map[string]string)
+	params := make(map[string][]string)
 	for {
 		key, value, ok := l.advanceParam()
 		if !ok {
 			break
 		}
-		params[key] = value
+		params[key] = append(params[key], value)
 	}
 	if kind == token.RUN || kind == token.COPY {
 		if l.containsHeredoc() {
@@ -127,7 +127,7 @@ func (l *Lexer) buildToken(kind int) token.Token {
 	}
 }
 
-func (l *Lexer) buildHereDocToken(kind int, params map[string]string) token.Token {
+func (l *Lexer) buildHereDocToken(kind int, params map[string][]string) token.Token {
 	// Get identifier and go until end
 	heredocContent := []string{}
 	encounteredRedirection := strings.HasPrefix(l.lines[l.currentLine][l.currentIndex:], "<<-")

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -237,12 +237,12 @@ func TestFromParsing(t *testing.T) {
 				},
 				{
 					Kind:    token.COPY,
-					Params:  map[string]string{"from": "base"},
+					Params:  map[string][]string{"from": {"base"}},
 					Content: "./source1 ./source2 ../../dest",
 				},
 				{
 					Kind:    token.COPY,
-					Params:  map[string]string{"from": "base"},
+					Params:  map[string][]string{"from": {"base"}},
 					Content: "./source1 ./source2 ../../dest",
 				},
 			},
@@ -525,8 +525,36 @@ func TestInstructionParsing(t *testing.T) {
 				Cmd:       []string{"cp", "./a", "./b"},
 				ShellForm: false,
 				IsHeredoc: false,
+				Mount:     []string{},
+				Network:   "",
+				Security:  "",
+				Device:    "",
 			}},
 		},
+		{
+			Input: []token.Token{
+				{
+					Kind:    token.RUN,
+					Content: "cp ./a ./b",
+					Params: map[string][]string{
+						"security": {"sandbox"},
+						"device":   {"gpu"},
+						"mount":    {"test1", "test2"},
+						"network":  {"nono"},
+					},
+				},
+			},
+			Expected: []ast.InstructionNode{&ast.RunInstructionNode{
+				Cmd:       []string{"cp", "./a", "./b"},
+				ShellForm: false,
+				IsHeredoc: false,
+				Mount:     []string{"test1", "test2"},
+				Network:   "nono",
+				Security:  "sandbox",
+				Device:    "gpu",
+			}},
+		},
+
 		{
 			Input: []token.Token{
 				{
@@ -540,6 +568,10 @@ func TestInstructionParsing(t *testing.T) {
 				Cmd:       []string{"EOT bash", "set -ex", "apt-get update", "apt-get install -y vim", "EOT"},
 				ShellForm: false,
 				IsHeredoc: true,
+				Mount:     []string{},
+				Network:   "",
+				Security:  "",
+				Device:    "",
 			}},
 		},
 		{

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -53,7 +53,7 @@ var TokenLookupTable = map[string]int{
 
 type Token struct {
 	Kind               int
-	Params             map[string]string
+	Params             map[string][]string
 	Content            string
 	InlineComment      string
 	MultiLineContent   []string //This can only contain content for instructions that support heredoc (which should be COPY and RUN)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Get value from passed map with a default
-func GetFromParamsWithDefault(m map[string]string, k string, d string) string {
+func GetFromParamsWithDefault(m map[string][]string, k string, d []string) []string {
 	if v, ok := m[k]; ok {
 		return v
 	}


### PR DESCRIPTION
# Changes:
- refactor param structure to support multiple values
- add paramter support to run according to current state of [docs](https://docs.docker.com/reference/dockerfile/#run)


Closes #3